### PR TITLE
feat: add scheduling and scaling permissions for FinOps optimization

### DIFF
--- a/cxm-integration-aws-sub-account.yaml
+++ b/cxm-integration-aws-sub-account.yaml
@@ -23,11 +23,11 @@ Parameters:
   # Feature toggles
   EnableScheduling:
     Type: String
-    Default: "true"
+    Default: "false"
     AllowedValues:
       - "true"
       - "false"
-    Description: Enable scheduling and scaling permissions for FinOps cost optimization (stop/start EC2, RDS, scale ECS, ASG, etc.)
+    Description: Enable scheduling and scaling permissions for FinOps cost optimization (disabled by default)
 
 Conditions:
   SchedulingEnabled: !Equals [!Ref EnableScheduling, "true"]
@@ -191,7 +191,9 @@ Resources:
               # ASG Scaling
               - autoscaling:UpdateAutoScalingGroup
               - autoscaling:SetDesiredCapacity
-              # Application Auto Scaling
+              # Application Auto Scaling (NOTE: covers all App Auto Scaling
+              # namespaces — ECS, DynamoDB, AppStream, etc. — AWS does not
+              # offer namespace-scoped IAM actions for this service)
               - application-autoscaling:RegisterScalableTarget
               # ElastiCache Scaling (NOTE: these actions are broader than scaling
               # alone — they also allow changing engine versions, parameter groups,

--- a/cxm-integration-aws-sub-account.yaml
+++ b/cxm-integration-aws-sub-account.yaml
@@ -115,6 +115,42 @@ Resources:
               - memorydb:PurchaseReservedNodesOffering
               # Saving Plans full management
               - savingsplans:*
+          # Scaling & stop/start permissions (FinOps cost optimization)
+          - Sid: SchedulingPermissions
+            Effect: Allow
+            Resource: "*"
+            Action:
+              # ECS Scaling
+              - ecs:UpdateService
+              # EC2 Stop/Start
+              - ec2:StartInstances
+              - ec2:StopInstances
+              # RDS Stop/Start
+              - rds:StartDBInstance
+              - rds:StopDBInstance
+              - rds:StartDBCluster
+              - rds:StopDBCluster
+              # Lambda Concurrency
+              - lambda:PutProvisionedConcurrencyConfig
+              - lambda:DeleteProvisionedConcurrencyConfig
+              - lambda:PutFunctionConcurrency
+              - lambda:DeleteFunctionConcurrency
+              # EKS Nodegroup Scaling
+              - eks:UpdateNodegroupConfig
+              # ASG Scaling
+              - autoscaling:UpdateAutoScalingGroup
+              - autoscaling:SetDesiredCapacity
+              # Application Auto Scaling
+              - application-autoscaling:RegisterScalableTarget
+              # ElastiCache Scaling
+              - elasticache:ModifyReplicationGroup
+              - elasticache:ModifyCacheCluster
+              # Redshift Scaling
+              - redshift:PauseCluster
+              - redshift:ResumeCluster
+              - redshift:ResizeCluster
+              # SageMaker Scaling
+              - sagemaker:UpdateEndpointWeightsAndCapacities
           # Explicitly denying data plane API Calls
           - Effect: Deny
             Resource: "*"

--- a/cxm-integration-aws-sub-account.yaml
+++ b/cxm-integration-aws-sub-account.yaml
@@ -20,6 +20,17 @@ Parameters:
     Type: String
     Default: cxm
     Description: Generic ID to namespace the stacks
+  # Feature toggles
+  EnableScheduling:
+    Type: String
+    Default: "true"
+    AllowedValues:
+      - "true"
+      - "false"
+    Description: Enable scheduling and scaling permissions for FinOps cost optimization (stop/start EC2, RDS, scale ECS, ASG, etc.)
+
+Conditions:
+  SchedulingEnabled: !Equals [!Ref EnableScheduling, "true"]
 
 Resources:
 
@@ -115,7 +126,47 @@ Resources:
               - memorydb:PurchaseReservedNodesOffering
               # Saving Plans full management
               - savingsplans:*
-          # Scaling & stop/start permissions (FinOps cost optimization)
+          # Explicitly denying data plane API Calls
+          - Sid: ExplicitDenyToDataPlane
+            Effect: Deny
+            Resource: "*"
+            Action:
+              - athena:StartCalculationExecution
+              - athena:StartQueryExecution
+              - dynamodb:GetItem
+              - dynamodb:BatchGetItem
+              - dynamodb:Query
+              - dynamodb:Scan
+              - ec2:GetConsoleOutput
+              - ec2:GetConsoleScreenshot
+              - ecr:BatchGetImage
+              - ecr:GetAuthorizationToken
+              - ecr:GetDownloadUrlForLayer
+              - ecs:RegisterTaskDefinition
+              - kinesis:GetRecords
+              - kinesis:GetShardIterator
+              - lambda:GetFunction
+              - logs:GetLogEvents
+              - sdb:Select*
+              - sqs:ReceiveMessage
+              - rds-data:*
+
+  ################################################################
+  #
+  # Scheduling & Scaling (FinOps cost optimization)
+  # Only created when EnableScheduling is "true"
+  #
+  ################################################################
+  SchedulingPolicy:
+    Type: AWS::IAM::Policy
+    Condition: SchedulingEnabled
+    Properties:
+      PolicyName: !Sub '${Prefix}-asset-crawler-scheduling'
+      Roles:
+        - !Ref 'CxmAssetCrawlerRole'
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
           - Sid: SchedulingPermissions
             Effect: Allow
             Resource: "*"
@@ -142,37 +193,18 @@ Resources:
               - autoscaling:SetDesiredCapacity
               # Application Auto Scaling
               - application-autoscaling:RegisterScalableTarget
-              # ElastiCache Scaling
+              # ElastiCache Scaling (NOTE: these actions are broader than scaling
+              # alone — they also allow changing engine versions, parameter groups,
+              # etc. — but AWS does not offer finer-grained actions)
               - elasticache:ModifyReplicationGroup
               - elasticache:ModifyCacheCluster
-              # Redshift Scaling
+              # Redshift Scaling (NOTE: ResizeCluster also allows changing node
+              # types, not just counts, which could affect costs)
               - redshift:PauseCluster
               - redshift:ResumeCluster
               - redshift:ResizeCluster
               # SageMaker Scaling
               - sagemaker:UpdateEndpointWeightsAndCapacities
-          # Explicitly denying data plane API Calls
-          - Effect: Deny
-            Resource: "*"
-            Action:
-              - athena:StartCalculationExecution
-              - athena:StartQueryExecution
-              - dynamodb:GetItem
-              - dynamodb:BatchGetItem
-              - dynamodb:Query
-              - dynamodb:Scan
-              - ec2:GetConsoleOutput
-              - ec2:GetConsoleScreenshot
-              - ecr:BatchGetImage
-              - ecr:GetAuthorizationToken
-              - ecr:GetDownloadUrlForLayer
-              - kinesis:GetRecords
-              - kinesis:GetShardIterator
-              - lambda:GetFunction
-              - logs:GetLogEvents
-              - sdb:Select*
-              - sqs:ReceiveMessage
-              - rds-data:*
 
   ################################################################
   #


### PR DESCRIPTION
## Summary
- Adds scheduling and scaling IAM permissions to the sub-account asset crawler role, enabling FinOps cost optimization actions in customer environments
- Permissions ported from the internal daneel-readonly module and cover: ECS, EC2, RDS, Lambda, EKS, ASG, Application Auto Scaling, ElastiCache, Redshift, and SageMaker
- New `SchedulingPermissions` statement added before the existing data-plane deny block

## Test plan
- [ ] Validate template with `aws cloudformation validate-template`
- [ ] Deploy to a sandbox account and verify the IAM policy contains all new actions
- [ ] Confirm data-plane deny statements still take precedence
- [ ] Test a scheduling action (e.g. `ec2:StopInstances`) through the assumed role