### PR TITLE
fix: add explicit bedrock read permissions to crawler roles

### DIFF
--- a/cxm-integration-aws-root.yaml
+++ b/cxm-integration-aws-root.yaml
@@ -122,6 +122,12 @@ Resources:
               - memorydb:PurchaseReservedNodesOffering
               # Saving Plans full management
               - savingsplans:*
+          - Sid: BedrockInventoryPermissions
+            Effect: Allow
+            Resource: "*"
+            Action:
+              - bedrock:List*
+              - bedrock:Get*
           - Sid: ManageReportDefinitions
             Effect: Allow
             Action:

--- a/cxm-integration-aws-sub-account.yaml
+++ b/cxm-integration-aws-sub-account.yaml
@@ -126,6 +126,12 @@ Resources:
               - memorydb:PurchaseReservedNodesOffering
               # Saving Plans full management
               - savingsplans:*
+          - Sid: BedrockInventoryPermissions
+            Effect: Allow
+            Resource: "*"
+            Action:
+              - bedrock:List*
+              - bedrock:Get*
           # Explicitly denying data plane API Calls
           - Sid: ExplicitDenyToDataPlane
             Effect: Deny


### PR DESCRIPTION
## Summary

- Add `bedrock:List*` + `bedrock:Get*` to both **root** (`cxm-integration-aws-root.yaml` — org crawler role) and **sub-account** (`cxm-integration-aws-sub-account.yaml` — asset crawler role) templates
- AWS managed `ReadOnlyAccess` v186 is missing `bedrock:ListImportedModels` and `bedrock:ListMarketplaceModelEndpoints`, causing `AccessDeniedException` in the inventory crawler

**Companion PRs:**
- cxmlabs/koomo#5582 — crawler resilience for `UnknownOperationException` and `InternalServerErrorException`
- cxmlabs/terraform-aws-cxm-integration#37 — same IAM fix for the Terraform/StackSet integration path

## Test plan

- [x] CloudFormation YAML validates (no syntax errors)
- [ ] Deploy updated stacks to cava and verify bedrock crawlers succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)