### PR TITLE
fix(sub-account): restore single-region guard for global IAM roles

### DIFF
--- a/cxm-integration-aws-sub-account.yaml
+++ b/cxm-integration-aws-sub-account.yaml
@@ -15,6 +15,15 @@ Parameters:
     Description: Your 12-digit AWS Organizations management account ID
     AllowedPattern: '^\d{12}$'
     ConstraintDescription: Must be a 12-digit AWS account ID
+  # Regions
+  ManagementRegion:
+    Type: String
+    Default: "us-east-1"
+    Description: >-
+      Single region in which the (global) IAM roles are created. IAM roles are
+      global, so in a multi-region StackSet they must be created in exactly one
+      region to avoid "already exists" collisions; EventBridge rules deploy to
+      every region regardless.
   # Prefix
   Prefix:
     Type: String
@@ -31,6 +40,8 @@ Parameters:
 
 Conditions:
   SchedulingEnabled: !Equals [!Ref EnableScheduling, "true"]
+  isManagementRegion: !Equals [!Ref AWS::Region, !Ref ManagementRegion]
+  isSchedulingAndManagementRegion: !And [Condition: SchedulingEnabled, Condition: isManagementRegion]
 
 Resources:
 
@@ -41,6 +52,7 @@ Resources:
   ################################################################
   CxmAssetCrawlerRole:
     Type: AWS::IAM::Role
+    Condition: isManagementRegion  # Only one role per account (IAM is global)
     DependsOn: CloudFormationNotifier
     Properties:
       RoleName: !Sub '${Prefix}-asset-crawler'
@@ -71,6 +83,7 @@ Resources:
 
   InventoryPolicy:
     Type: AWS::IAM::Policy
+    Condition: isManagementRegion  # Only one per account (attaches to the global role)
     Properties:
       PolicyName: !Sub '${Prefix}-asset-crawler-readonly'
       Roles:
@@ -167,7 +180,7 @@ Resources:
   ################################################################
   SchedulingPolicy:
     Type: AWS::IAM::Policy
-    Condition: SchedulingEnabled
+    Condition: isSchedulingAndManagementRegion  # Only one per account (attaches to the global role)
     Properties:
       PolicyName: !Sub '${Prefix}-asset-crawler-scheduling'
       Roles:
@@ -223,6 +236,7 @@ Resources:
   ################################################################
   IAMCrossAccountNotificationRole:
     Type: AWS::IAM::Role
+    Condition: isManagementRegion  # Only one role per account (IAM is global)
     Properties:
       RoleName: !Sub '${Prefix}-feedback-loop-control-plane'
       MaxSessionDuration: 43200
@@ -289,11 +303,13 @@ Outputs:
     Description: Actual AWS region where this stack is running
     Value: !Ref AWS::Region
 
-  # Asset crawler
+  # Asset crawler (created only in the management region — see isManagementRegion)
   CxmAssetCrawlerRoleArn:
+    Condition: isManagementRegion
     Description: ARN of the Asset Crawler IAM Role
     Value: !GetAtt CxmAssetCrawlerRole.Arn
   CxmAssetCrawlerRoleId:
+    Condition: isManagementRegion
     Description: Id of the Asset Crawler IAM Role
     Value: !GetAtt CxmAssetCrawlerRole.RoleId
 


### PR DESCRIPTION
## Problem

`cxm-integration-aws-sub-account.yaml` creates global IAM roles (`asset-crawler`, `feedback-loop-control-plane`) and their policies **unconditionally**. IAM is a global service, so when this template is deployed as a multi-region StackSet, every region tries to create the *same* role name in each account. The first region wins; every subsequent region fails:

```
Resource of type 'AWS::IAM::Role' with identifier 'cxm-asset-crawler' already exists.
The policy cxm-asset-crawler-readonly already exists on the role cxm-asset-crawler.
```

Under `FailureToleranceCount=0` the first collision cancels the whole operation.

The template used to guard these resources with a `ManagementRegion` parameter + `isManagementRegion` condition (IAM in one region, EventBridge rules everywhere). That guard was lost when the `ManagementRegion` parameter was removed, and the regression went unnoticed because single-region deployments never hit it.

## Fix

- Reintroduce the `ManagementRegion` parameter (default `us-east-1`).
- Add `isManagementRegion` + `isSchedulingAndManagementRegion` conditions.
- Gate the IAM roles/policies and their outputs on `isManagementRegion`:
  `CxmAssetCrawlerRole`, `InventoryPolicy`, `SchedulingPolicy`, `IAMCrossAccountNotificationRole`, `CxmAssetCrawlerRoleArn`/`Id` outputs.
- EventBridge rules (`CloudFormationNotifier`) still deploy to every region.

Verified with a live multi-region SERVICE_MANAGED StackSet across an org: prior to the fix, deployment collided across regions; after, IAM roles are created once per account (in `ManagementRegion`) and instances converge cleanly. `cfn-lint` clean.