### PR TITLE
fix(sub-account): stop denying lambda:ListFunctions (inventory list, not data-plane)

### DIFF
--- a/cxm-integration-aws-sub-account.yaml
+++ b/cxm-integration-aws-sub-account.yaml
@@ -165,8 +165,6 @@ Resources:
               - kinesis:GetRecords
               - kinesis:GetShardIterator
               - lambda:GetFunction
-              - lambda:ListFunctions
-              - lambda:ListProvisionedConcurrencyConfigs
               - logs:GetLogEvents
               - sdb:Select*
               - sqs:ReceiveMessage


### PR DESCRIPTION
## Problem

cava metadata crawler fails **306×/night** on the `cxm__aws__services__metadata__aws_lambda_functions` asset:

```
[CloudQuery stderr] ERR table resolver finished with error
error="operation error Lambda: ListFunctions ... AccessDenied ...
User: arn:aws:sts::<acct>:assumed-role/cxm-cfn-cava-asset-crawler is not authorized to perform: lambda:ListFunctions"
```

This is the dominant Dagster failure on the cava infra-health report — even though the role has `ReadOnlyAccess` attached.

## Root cause

The `${Prefix}-asset-crawler-readonly` policy's `ExplicitDenyToDataPlane` statement listed:

```yaml
- lambda:GetFunction
- lambda:ListFunctions                       # <-- inventory list, wrongly denied
- lambda:ListProvisionedConcurrencyConfigs   # <-- inventory list, wrongly denied
- logs:GetLogEvents
```

An explicit `Deny` **overrides** the `ReadOnlyAccess` Allow, so the crawler 403s on `lambda:ListFunctions` in every account. The intent of that statement — block the vendor role from reading actual customer *data* (dynamodb items, kinesis records, `logs:GetLogEvents`, sqs messages, console output, athena results) — is correct, but `ListFunctions` / `ListProvisionedConcurrencyConfigs` are **inventory metadata list calls**, not data-plane, and the metadata crawler needs `ListFunctions`.

## Comparison with the Terraform integration

The production tenant uses `terraform-aws-cxm-integration`. Its equivalent `ExplicitDenyToDataPlane` (`terraform-aws-sub-account-cxm-enablement/policies.tf`) denies `lambda:GetFunction` + `logs:GetLogEvents` but **does not** deny `lambda:ListFunctions` / `ListProvisionedConcurrencyConfigs` — which is why production's lambda inventory works. This PR aligns the CloudFormation template with that Terraform baseline.

## Fix

Remove `lambda:ListFunctions` and `lambda:ListProvisionedConcurrencyConfigs` from the deny list. `lambda:GetFunction` stays denied (returns a presigned code-download URL — genuine data-plane; the crawler doesn't need it, matching TF).

## Rollout

Customer-facing CloudFormation. Re-deploy the sub-account stack/StackSet on cava's accounts to clear the 306 nightly `lambda:ListFunctions` denials.