### PR TITLE
fix(sub-account): allow lambda:GetFunction for inventory crawler

### DIFF
--- a/cxm-integration-aws-sub-account.yaml
+++ b/cxm-integration-aws-sub-account.yaml
@@ -164,7 +164,6 @@ Resources:
               - ecs:RegisterTaskDefinition
               - kinesis:GetRecords
               - kinesis:GetShardIterator
-              - lambda:GetFunction
               - logs:GetLogEvents
               - sdb:Select*
               - sqs:ReceiveMessage


### PR DESCRIPTION
## Why

The `aws_lambda_functions` inventory crawler calls both `lambda:ListFunctions` and `lambda:GetFunction`. PR #19 removed `ListFunctions` from `ExplicitDenyToDataPlane` but left `GetFunction` denied, which just moved the failure one call downstream: nightly Dagster shows ~352 `lambda:GetFunction` AccessDenied errors after ListFunctions started working.

`GetFunction` returns function configuration (the reason inventory needs it). It also returns a presigned code-download URL — that is why it was originally in the deny — but an inventory crawler reading configuration is the intended use, and the code URL is not exfiltrated anywhere.

## Change

Remove `lambda:GetFunction` from the `ExplicitDenyToDataPlane` statement.

Mirrored in the Terraform integration template in a companion PR so CFN- and TF-enrolled accounts stay identical.