### PR TITLE
Let CloudFormation customers enable in-place log querying with a bucket and KMS resource-policy grant

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ This project deploys CloudFormation stacks that grant CXM cross-account read acc
 | `CostAndUsageReportS3BucketName` | Yes | — | S3 bucket name storing your CUR data (bucket name only, not the ARN — e.g. `my-cur-bucket`) |
 | `CostAndUsageReportS3BucketKmsKeyArn` | No | `""` | KMS key ARN if your CUR bucket is encrypted (e.g. `arn:aws:kms:us-east-1:123456789012:key/...`) |
 | `CostAndUsageBucketRegion` | No | `us-east-1` | Region of the CUR S3 bucket |
+| `EnableInPlaceQueryGrant` | No | `false` | Set to `true` to render the in-place query statements as stack outputs. See [Querying logs in place](#querying-logs-in-place) |
+| `InPlaceQueryObjectPrefix` | No | `AWSLogs` | Object key prefix the in-place grant is narrowed to, no trailing slash. Set to your report prefix for a CUR bucket |
 | `Prefix` | No | `cxm` | Namespace prefix for resource names |
 
 ### Sub-Account StackSet (`params-cxm-sub-accounts.json`)
@@ -60,6 +62,8 @@ This project deploys CloudFormation stacks that grant CXM cross-account read acc
 | `CXMCustomerAccountId` | Yes | — | 12-digit CXM AWS account ID provided by CXM (same as root) |
 | `VPCFlowLogsBucketName` | Yes | — | S3 bucket name storing centralized VPC Flow Logs |
 | `VPCFlowLogsBucketKmsKeyArn` | No | `""` | KMS key ARN if the Flow Logs bucket is encrypted |
+| `EnableInPlaceQueryGrant` | No | `false` | Set to `true` to render the in-place query statements as stack outputs. See [Querying logs in place](#querying-logs-in-place) |
+| `InPlaceQueryObjectPrefix` | No | `AWSLogs` | Object key prefix the in-place grant is narrowed to, no trailing slash |
 | `Prefix` | No | `cxm` | Namespace prefix for resource names |
 
 ## Deployment
@@ -204,6 +208,83 @@ Check that:
 - `ResourcesCreated` shows `All resources created (org crawler, CUR reader, notifications)`
 
 Share the outputs with CXM to complete the integration.
+
+## Querying logs in place
+
+CXM can analyse your logs **in place** — reading the objects straight out of your bucket instead of copying them into ours. Nothing leaves your account and you pay no duplicate storage.
+
+This needs a grant the reader roles above cannot provide. Athena reads S3 as the principal that submitted the query and cannot be handed an assumed-role session, so the cross-account role and its external ID never enter the read path. The bucket must grant access in its **own** policy — a resource policy — and, when the objects are encrypted with a customer managed key, the key must do the same in its key policy.
+
+### These templates render the statements, they do not apply them
+
+Set `EnableInPlaceQueryGrant=true` and the stack outputs `InPlaceQueryBucketPolicyStatements` (and `InPlaceQueryKmsKeyPolicyStatement`, when a KMS key ARN is set). **You merge them into your existing policies yourself.** No bucket or key policy resource is created, so turning the parameter on changes nothing in your account.
+
+That is deliberate. `AWS::S3::BucketPolicy` replaces the **whole** bucket policy and CloudFormation has no way to read the policy already on the bucket, so it cannot merge. CloudTrail and VPC Flow Logs buckets always carry AWS log-delivery statements (`cloudtrail.amazonaws.com`, `delivery.logs.amazonaws.com`); a managed bucket policy would silently delete them and stop your log delivery. CloudFormation likewise has no resource type for the policy of an existing KMS key.
+
+Read the statements out of the stack outputs:
+
+```bash
+aws cloudformation describe-stacks \
+  --stack-name CxmIntegrationStack-FlowLogs \
+  --query "Stacks[0].Outputs[?starts_with(OutputKey, 'InPlaceQuery')]" \
+  --output text \
+  --region $FLOWLOGS_REGION
+```
+
+The bucket grant looks like this, with your account ID, bucket name and prefix already filled in:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "CxMInPlaceGetObject",
+      "Effect": "Allow",
+      "Principal": { "AWS": "arn:aws:iam::000000000000:root" },
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::example-log-bucket/AWSLogs/*"
+    },
+    {
+      "Sid": "CxMInPlaceListBucket",
+      "Effect": "Allow",
+      "Principal": { "AWS": "arn:aws:iam::000000000000:root" },
+      "Action": "s3:ListBucket",
+      "Resource": "arn:aws:s3:::example-log-bucket",
+      "Condition": { "StringLike": { "s3:prefix": "AWSLogs/*" } }
+    },
+    {
+      "Sid": "CxMInPlaceGetBucketLocation",
+      "Effect": "Allow",
+      "Principal": { "AWS": "arn:aws:iam::000000000000:root" },
+      "Action": "s3:GetBucketLocation",
+      "Resource": "arn:aws:s3:::example-log-bucket"
+    }
+  ]
+}
+```
+
+And the key grant:
+
+```json
+{
+  "Sid": "CxMInPlaceDecrypt",
+  "Effect": "Allow",
+  "Principal": { "AWS": "arn:aws:iam::000000000000:root" },
+  "Action": ["kms:Decrypt", "kms:DescribeKey"],
+  "Resource": "*"
+}
+```
+
+> **Merge the KMS statement into the key's current policy — never replace it.** A key policy replaced without its administrative statements locks the key permanently: no rotation, no deletion and no further policy edit, by anyone, including you. Read the current policy first with `aws kms get-key-policy --key-id <KEY_ARN> --policy-name default`, add the statement to its `Statement` array, and put the whole document back.
+
+Four points to keep when you adapt these statements:
+
+- **Keep the three bucket statements separate.** `s3:GetBucketLocation` does not support the `s3:prefix` condition key, so folding it in with `s3:ListBucket` makes AWS reject the whole policy as `MalformedPolicy`. A rejected `put-bucket-policy` leaves the previous policy in place, which looks like success — always read the policy back afterwards.
+- **Do not add an `aws:CalledVia` condition.** Athena does not populate `aws:CalledVia` on its scan requests, so the condition denies the very queries you are enabling.
+- **The principal is the CXM account, not a role.** Access is narrowed by object prefix instead. Our submitting roles are named per tenant and per service, so naming them would break your policy every time one is renamed.
+- **`kms:GenerateDataKey` is not needed.** It is write-side only; in-place querying only ever decrypts.
+
+The same statements are produced by the Terraform onboarding module, so the two routes grant identical access.
 
 ## Updating
 

--- a/cxm-integration-aws-flowlogs.yaml
+++ b/cxm-integration-aws-flowlogs.yaml
@@ -20,6 +20,18 @@ Parameters:
     Type: String
     Default: ''
     Description: Optional - ARN of the KMS key used to encrypt VPC Flow Logs data in S3.
+  # In-place query access
+  EnableInPlaceQueryGrant:
+    Type: String
+    Default: 'false'
+    AllowedValues: ['false', 'true']
+    Description: Set to true to render the bucket and KMS key policy statements CXM needs to query the bucket in place. Rendering changes nothing in your account — the statements appear as stack outputs for you to merge into the bucket's existing policy yourself.
+  InPlaceQueryObjectPrefix:
+    Type: String
+    Default: AWSLogs
+    Description: Object key prefix the in-place query grant is narrowed to, without a trailing slash.
+    AllowedPattern: '^[A-Za-z0-9!_.*''()\-]+(/[A-Za-z0-9!_.*''()\-]+)*$'
+    ConstraintDescription: Must be an S3 key prefix with no leading or trailing slash (e.g. AWSLogs)
   # Prefix / Suffix
   Prefix:
     Type: String
@@ -32,6 +44,8 @@ Parameters:
 
 Conditions:
   isKmsKeyArnSet: !Not [ !Equals [ !Ref VPCFlowLogsBucketKmsKeyArn, '' ] ]
+  isInPlaceQueryGrantEnabled: !Equals [ !Ref EnableInPlaceQueryGrant, 'true' ]
+  isInPlaceQueryKmsGrantNeeded: !And [ !Condition isInPlaceQueryGrantEnabled, !Condition isKmsKeyArnSet ]
 
 Resources:
 
@@ -154,6 +168,51 @@ Outputs:
   VPCFlowLogsBucketName:
     Description: Name of the S3 bucket storing VPC Flow Logs
     Value: !Ref VPCFlowLogsBucketName
+
+  # In-place query access. CloudFormation replaces the whole bucket policy and cannot read
+  # the existing one, so the statements are rendered for you to merge — no resource is created.
+  InPlaceQueryBucketPolicyStatements:
+    Condition: isInPlaceQueryGrantEnabled
+    Description: Bucket policy statements to merge into the bucket's existing policy so CXM can query it in place. Keep the three statements separate.
+    Value: !Sub |
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Sid": "CxMInPlaceGetObject",
+            "Effect": "Allow",
+            "Principal": { "AWS": "arn:aws:iam::${CXMCustomerAccountId}:root" },
+            "Action": "s3:GetObject",
+            "Resource": "arn:aws:s3:::${VPCFlowLogsBucketName}/${InPlaceQueryObjectPrefix}/*"
+          },
+          {
+            "Sid": "CxMInPlaceListBucket",
+            "Effect": "Allow",
+            "Principal": { "AWS": "arn:aws:iam::${CXMCustomerAccountId}:root" },
+            "Action": "s3:ListBucket",
+            "Resource": "arn:aws:s3:::${VPCFlowLogsBucketName}",
+            "Condition": { "StringLike": { "s3:prefix": "${InPlaceQueryObjectPrefix}/*" } }
+          },
+          {
+            "Sid": "CxMInPlaceGetBucketLocation",
+            "Effect": "Allow",
+            "Principal": { "AWS": "arn:aws:iam::${CXMCustomerAccountId}:root" },
+            "Action": "s3:GetBucketLocation",
+            "Resource": "arn:aws:s3:::${VPCFlowLogsBucketName}"
+          }
+        ]
+      }
+  InPlaceQueryKmsKeyPolicyStatement:
+    Condition: isInPlaceQueryKmsGrantNeeded
+    Description: KMS key policy statement to merge into the encryption key's existing policy. Merge it — replacing a key policy without its administrative statements locks the key permanently.
+    Value: !Sub |
+      {
+        "Sid": "CxMInPlaceDecrypt",
+        "Effect": "Allow",
+        "Principal": { "AWS": "arn:aws:iam::${CXMCustomerAccountId}:root" },
+        "Action": ["kms:Decrypt", "kms:DescribeKey"],
+        "Resource": "*"
+      }
 
   # Flow Logs Reader
   CxmFlowLogsReaderRoleArn:

--- a/cxm-integration-aws-root.yaml
+++ b/cxm-integration-aws-root.yaml
@@ -26,6 +26,18 @@ Parameters:
     Type: String
     Default: "us-east-1"
     Description: Region where the CUR S3 bucket lives. Deploy this stack to this region for full functionality.
+  # In-place query access
+  EnableInPlaceQueryGrant:
+    Type: String
+    Default: 'false'
+    AllowedValues: ['false', 'true']
+    Description: Set to true to render the bucket and KMS key policy statements CXM needs to query the bucket in place. Rendering changes nothing in your account — the statements appear as stack outputs for you to merge into the bucket's existing policy yourself.
+  InPlaceQueryObjectPrefix:
+    Type: String
+    Default: AWSLogs
+    Description: Object key prefix the in-place query grant is narrowed to, without a trailing slash. Set this to your report prefix for a CUR bucket.
+    AllowedPattern: '^[A-Za-z0-9!_.*''()\-]+(/[A-Za-z0-9!_.*''()\-]+)*$'
+    ConstraintDescription: Must be an S3 key prefix with no leading or trailing slash (e.g. AWSLogs)
   # Prefix
   Prefix:
     Type: String
@@ -35,6 +47,8 @@ Parameters:
 Conditions:
   isCostAndUsageBucketRegion: !Equals [!Ref AWS::Region, !Ref CostAndUsageBucketRegion]
   isCURKmsKeyArnSet: !Not [ !Equals [ !Ref CostAndUsageReportS3BucketKmsKeyArn, '' ] ]
+  isInPlaceQueryGrantEnabled: !Equals [ !Ref EnableInPlaceQueryGrant, 'true' ]
+  isInPlaceQueryKmsGrantNeeded: !And [ !Condition isInPlaceQueryGrantEnabled, !Condition isCURKmsKeyArnSet ]
 
 Resources:
 
@@ -436,6 +450,51 @@ Outputs:
   CostAndUsageBucketRegion:
     Description: Cost and Usage Bucket region
     Value: !Ref CostAndUsageBucketRegion
+
+  # In-place query access. CloudFormation replaces the whole bucket policy and cannot read
+  # the existing one, so the statements are rendered for you to merge — no resource is created.
+  InPlaceQueryBucketPolicyStatements:
+    Condition: isInPlaceQueryGrantEnabled
+    Description: Bucket policy statements to merge into the bucket's existing policy so CXM can query it in place. Keep the three statements separate.
+    Value: !Sub |
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Sid": "CxMInPlaceGetObject",
+            "Effect": "Allow",
+            "Principal": { "AWS": "arn:aws:iam::${CXMCustomerAccountId}:root" },
+            "Action": "s3:GetObject",
+            "Resource": "arn:aws:s3:::${CostAndUsageReportS3BucketName}/${InPlaceQueryObjectPrefix}/*"
+          },
+          {
+            "Sid": "CxMInPlaceListBucket",
+            "Effect": "Allow",
+            "Principal": { "AWS": "arn:aws:iam::${CXMCustomerAccountId}:root" },
+            "Action": "s3:ListBucket",
+            "Resource": "arn:aws:s3:::${CostAndUsageReportS3BucketName}",
+            "Condition": { "StringLike": { "s3:prefix": "${InPlaceQueryObjectPrefix}/*" } }
+          },
+          {
+            "Sid": "CxMInPlaceGetBucketLocation",
+            "Effect": "Allow",
+            "Principal": { "AWS": "arn:aws:iam::${CXMCustomerAccountId}:root" },
+            "Action": "s3:GetBucketLocation",
+            "Resource": "arn:aws:s3:::${CostAndUsageReportS3BucketName}"
+          }
+        ]
+      }
+  InPlaceQueryKmsKeyPolicyStatement:
+    Condition: isInPlaceQueryKmsGrantNeeded
+    Description: KMS key policy statement to merge into the encryption key's existing policy. Merge it — replacing a key policy without its administrative statements locks the key permanently.
+    Value: !Sub |
+      {
+        "Sid": "CxMInPlaceDecrypt",
+        "Effect": "Allow",
+        "Principal": { "AWS": "arn:aws:iam::${CXMCustomerAccountId}:root" },
+        "Action": ["kms:Decrypt", "kms:DescribeKey"],
+        "Resource": "*"
+      }
 
   # Notification role
   CxmNotificationRoleArn:


### PR DESCRIPTION
## Why

Customers onboard by **either** Terraform or CloudFormation. The Terraform module just
gained a resource-policy path for querying logs in place
(cxmlabs/terraform-aws-cxm-integration#39). Without the same thing here, CloudFormation
customers cannot enable in-place querying at all and the capability silently depends on
which onboarding route they happened to pick.

The existing grants in this repo are **identity** policies attached to a role in the
customer account, trusted from ours with an `sts:ExternalId` condition
(`CxmCostAndUsageReaderRole`, `CxmFlowLogsReaderRole`). They grant nothing on the query
path: Athena reads S3 as the principal that submitted the query and cannot be handed an
assumed-role session, so that role and its external ID never enter the read path. A
**resource** policy is required. None existed anywhere in this repo.

## What this adds

Two parameters on `cxm-integration-aws-root.yaml` (CUR bucket) and
`cxm-integration-aws-flowlogs.yaml` (VPC Flow Logs bucket):

| Parameter | Default | Effect |
|---|---|---|
| `EnableInPlaceQueryGrant` | `false` | When `true`, the stack renders the statements as outputs |
| `InPlaceQueryObjectPrefix` | `AWSLogs` | Prefix the grant is narrowed to, no trailing slash |

With the parameter set, the stack outputs `InPlaceQueryBucketPolicyStatements` and — when a
KMS key ARN is configured — `InPlaceQueryKmsKeyPolicyStatement`. The statements match the
Terraform module's:

| Sid | Action | Resource | Condition |
|---|---|---|---|
| `CxMInPlaceGetObject` | `s3:GetObject` | `arn:aws:s3:::<bucket>/AWSLogs/*` | — |
| `CxMInPlaceListBucket` | `s3:ListBucket` | `arn:aws:s3:::<bucket>` | `StringLike s3:prefix = AWSLogs/*` |
| `CxMInPlaceGetBucketLocation` | `s3:GetBucketLocation` | `arn:aws:s3:::<bucket>` | — |
| `CxMInPlaceDecrypt` (key policy) | `kms:Decrypt`, `kms:DescribeKey` | `*` | — |

Account-delegated principal (`arn:aws:iam::<CXM account>:root`), narrowed by object prefix,
never by role name — our submitting roles are named per tenant and per service, so naming
them would break the customer's policy on any rename. `kms:GenerateDataKey` is write-side
only and excluded.

Three constraints are load-bearing and pinned by comments in the templates and by the
README:

- **Three separate bucket statements are mandatory.** `s3:GetBucketLocation` does not
  support the `s3:prefix` condition key, so a combined statement is rejected as
  `MalformedPolicy` — and a rejected `put-bucket-policy` leaves the previous policy live,
  which reads as a passing test.
- **No `aws:CalledVia: athena.amazonaws.com` condition.** Athena does not populate
  `CalledVia` on its scan requests, so the condition denies Athena itself.
- **Merge the KMS statement, never replace the key policy.** A key policy replaced without
  its administrative statements locks the key permanently — no rotation, deletion or policy
  edit by anyone.

## Where CloudFormation forced a different approach than Terraform

**No managed policy resources at all — outputs only.** The Terraform PR ships an opt-in
`manage_bucket_policy` mode that merges via
`data.aws_s3_bucket_policy` → `source_policy_documents`. CloudFormation has no equivalent:
there is no way to read the policy already on a bucket, so `AWS::S3::BucketPolicy` can only
replace the whole document. CloudTrail and VPC Flow Logs buckets always carry AWS
log-delivery statements (`cloudtrail.amazonaws.com`, `delivery.logs.amazonaws.com`), so a
managed bucket policy here would silently delete them and stop log delivery. There is
therefore **no safe merge mode available in CloudFormation**, and this PR deliberately
offers none — not even opt-in.

The same applies harder to KMS: CloudFormation has no resource type for the policy of an
**existing** key (`AWS::KMS::Key` manages a key it owns), so the Terraform
`manage_kms_key_policy` / `existing_kms_key_policy_json` pair has no counterpart at all.

Consequence: the grant is delivered as documentation-grade outputs the customer merges by
hand, and the templates create nothing new.

## Validation

- `aws cloudformation validate-template` passes on both changed templates.
- `cfn-lint` (the CI gate) passes clean on both.
- Rendered outputs parsed as JSON with placeholder values and compared against the
  statements documented in the Terraform PR — identical Sids, order, actions, resources and
  conditions.
- **Zero-diff when the parameter is unset**, verified two ways: the diff is 199 pure
  additions confined to `Parameters`, `Conditions` and `Outputs` with no hunk touching
  `Resources`; and `get-template-summary` returns an identical `ResourceTypes` set for the
  old and new template on both files.

Not verified here:

- **No change set was created against a live stack** — no stack from either changed
  template is deployed in an account I have, and standing one up would create named IAM
  roles in a shared account. The structural evidence above is the substitute.
- **The end-to-end Athena probe** against a real bucket needs a live account and is the
  reviewer's apply-and-probe step.

## Gap worth knowing about

This repo has **no CloudTrail onboarding template** — only CUR (root), VPC Flow Logs, EKS
and the sub-account StackSet. So while the Terraform root module wires the in-place outputs
for both `cloudtrail` and `flowlogs`, CloudFormation parity for a CloudTrail log bucket is
blocked on a template that does not exist yet, not on this change. Adding one is a separate
piece of work.

## Scope

Additive only. No existing parameter default, resource, or output changes.

Closes CLO-6646.
